### PR TITLE
fix build and add instructions to README.md about building the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,22 @@ await perplexity.evolve({
 
 ---
 
+## 🛠️ DEVELOPMENT & BUILDING
+
+### 📋 Prerequisites
+- **Node.js** (v16 or higher)
+- **Git** (for cloning the repository)
+
+### 🎯 Auto-Detection Build (Recommended)
+```
+git clone https://github.com/inulute/perplexity-ai-app
+cd perplexity-ai-app
+npm run package-auto
+```
+> Automatically detects your OS and builds the appropriate package format
+
+---
+
 <div align="center">
   <img src="./assets/icons/svg/inulute.svg" alt="Inulute" width="70px">
   

--- a/build-auto.js
+++ b/build-auto.js
@@ -1,0 +1,59 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+
+function detectOS() {
+  const platform = os.platform();
+  
+  if (platform === 'win32') {
+    return 'windows';
+  } else if (platform === 'darwin') {
+    return 'mac';
+  } else if (platform === 'linux') {
+    // Check if it's Debian-based
+    try {
+      const osRelease = fs.readFileSync('/etc/os-release', 'utf-8').toLowerCase();
+      if (osRelease.includes('id=debian') || osRelease.includes('id=ubuntu')) {
+        return 'debian';
+      }
+      return 'linux-other';
+    } catch (e) {
+      return 'linux-other';
+    }
+  }
+  return 'unknown';
+}
+
+function runBuild() {
+  const detectedOS = detectOS();
+  console.log(`Detected OS: ${detectedOS}`);
+  
+  try {
+    switch (detectedOS) {
+      case 'windows':
+        console.log('Running Windows build...');
+        execSync('npm run package-win', { stdio: 'inherit' });
+        break;
+      case 'mac':
+        console.log('Running macOS build...');
+        execSync('npm run package-mac', { stdio: 'inherit' });
+        break;
+      case 'debian':
+        console.log('Running Debian/Ubuntu build...');
+        execSync('npm run package-linux', { stdio: 'inherit' });
+        break;
+      case 'linux-other':
+        console.log('Running Linux build (AppImage only to avoid fpm issues)...');
+        execSync('electron-builder --linux AppImage', { stdio: 'inherit' });
+        break;
+      default:
+        console.error(`Unsupported OS: ${detectedOS}`);
+        process.exit(1);
+    }
+  } catch (error) {
+    console.error('Build failed:', error.message);
+    process.exit(1);
+  }
+}
+
+runBuild();

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "package-win": "electron-builder --win",
     "package-mac": "electron-builder --mac",
     "package-linux": "electron-builder --linux",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "package-auto": "node build-auto.js"
   },
   "repository": "https://github.com/inulute/perplexity-ai-app",
-  "author": "inulute",
+  "author": "inulute <inulute@users.noreply.github.com>",
   "license": "GPL-3.0-only",
   "dependencies": {
     "electron-clipboard-extended": "^1.1.1",


### PR DESCRIPTION
adding the github email to author fixes:
```
❯ npm run package-linux

> perplexity-ai-app@4.0.0 package-linux
> electron-builder --linux

  • electron-builder  version=25.1.8 os=6.16.0-cachyos
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=release-builds/builder-effective-config.yaml
  • executing @electron/rebuild  electronVersion=33.0.2 arch=x64 buildFromSource=false appDir=./
  • installing native dependencies  arch=x64
  • completed installing native dependencies
  • packaging       platform=linux arch=x64 electron=33.0.2 appOutDir=release-builds/linux-unpacked
  • building        target=AppImage arch=x64 file=release-builds/Perplexity AI-4.0.0.AppImage
  • default Electron icon is used  reason=application icon is not set
  • building        target=deb arch=x64 file=release-builds/Perplexity AI-4.0.0.deb
  • adding autoupdate files for: deb. (Beta feature)  resourceDir=release-builds/linux-unpacked/resources
  ⨯ Please specify author 'email' in the application package.json

See https://docs.npmjs.com/files/package.json#people-fields-author-contributors

It is required to set Linux .deb package maintainer. Or you can set maintainer in the custom linux options.
(see https://www.electron.build/linux).
  failedTask=build stackTrace=Error: Please specify author 'email' in the application package.json
                                                                                                                                                                                                                                                                                                            See https://docs.npmjs.com/files/package.json#people-fields-author-contributors
                                                                                                                                                                                                                                                                                                            It is required to set Linux .deb package maintainer. Or you can set maintainer in the custom linux options.
(see https://www.electron.build/linux).
                                                                                                                                                                                                                                                                                                                at FpmTarget.computeFpmMetaInfoOptions (/home/floory/.git-projects/inulude/node_modules/app-builder-lib/src/targets/FpmTarget.ts:94:13)
    at FpmTarget.build (/home/floory/.git-projects/inulude/node_modules/app-builder-lib/src/targets/FpmTarget.ts:165:25)
    at /home/floory/.git-projects/inulude/node_modules/app-builder-lib/src/platformPackager.ts:156:11
    at async Promise.all (index 0)
    at AsyncTaskManager.awaitTasks (/home/floory/.git-projects/inulude/node_modules/builder-util/src/asyncTaskManager.ts:65:25)
    at Packager.doBuild (/home/floory/.git-projects/inulude/node_modules/app-builder-lib/src/packager.ts:475:5)
    at executeFinally (/home/floory/.git-projects/inulude/node_modules/builder-util/src/promise.ts:12:14)
    at Packager.build (/home/floory/.git-projects/inulude/node_modules/app-builder-lib/src/packager.ts:393:31)
    at executeFinally (/home/floory/.git-projects/inulude/node_modules/builder-util/src/promise.ts:12:14)
```

making .deb only compile on debian fixes fpm dependency to allow building on other distros besides debian:
```
❯ npm run package-linux

> perplexity-ai-app@4.0.0 package-linux
> electron-builder --linux

  • electron-builder  version=25.1.8 os=6.16.0-cachyos
  • loaded configuration  file=package.json ("build" field)
  • writing effective config  file=release-builds/builder-effective-config.yaml
  • executing @electron/rebuild  electronVersion=33.0.2 arch=x64 buildFromSource=false appDir=./
  • installing native dependencies  arch=x64
  • completed installing native dependencies
  • packaging       platform=linux arch=x64 electron=33.0.2 appOutDir=release-builds/linux-unpacked
  • building        target=AppImage arch=x64 file=release-builds/Perplexity AI-4.0.0.AppImage
  • default Electron icon is used  reason=application icon is not set
  • building        target=deb arch=x64 file=release-builds/Perplexity AI-4.0.0.deb
  • adding autoupdate files for: deb. (Beta feature)  resourceDir=release-builds/linux-unpacked/resources
  ⨯ cannot execute  cause=fork/exec /home/floory/.cache/electron-builder/fpm/fpm-1.9.3-2.3.1-linux-x86_64/fpm: no such file or directory
                    command=/home/floory/.cache/electron-builder/fpm/fpm-1.9.3-2.3.1-linux-x86_64/fpm -s dir --force -t deb -d libnotify4 -d libxtst6 -d libnss3 --deb-recommends libappindicator3-1 --deb-compression xz --architecture amd64 --after-install /tmp/t-AmGBrQ/1-after-install --after-remove /tmp/t-AmGBrQ/0-after-remove --description 'Perplexity AI - system-wide search and context menu integration
     Perplexity AI by inulute' --version 4.0.0 --package '/home/floory/.git-projects/inulude/release-builds/Perplexity AI-4.0.0.deb' --name perplexity-ai-app --maintainer 'inulute <inulute@users.noreply.github.com>' --url 'https://github.com/inulute/perplexity-ai-app#readme' --vendor 'inulute <inulute@users.noreply.github.com>' --deb-priority optional --license GPL-3.0-only '/home/floory/.git-projects/inulude/release-builds/linux-unpacked/=/opt/Perplexity AI' /home/floory/.git-projects/inulude/node_modules/app-builder-lib/templates/icons/electron-linux/16x16.png=/usr/share/icons/hicolor/16x16/apps/perplexity-ai-app.png /home/floory/.git-projects/inulude/node_modules/app-builder-lib/templates/icons/electron-linux/32x32.png=/usr/share/icons/hicolor/32x32/apps/perplexity-ai-app.png /home/floory/.git-projects/inulude/node_modules/app-builder-lib/templates/icons/electron-linux/48x48.png=/usr/share/icons/hicolor/48x48/apps/perplexity-ai-app.png /home/floory/.git-projects/inulude/node_modules/app-builder-lib/templates/icons/electron-linux/64x64.png=/usr/share/icons/hicolor/64x64/apps/perplexity-ai-app.png /home/floory/.git-projects/inulude/node_modules/app-builder-lib/templates/icons/electron-linux/128x128.png=/usr/share/icons/hicolor/128x128/apps/perplexity-ai-app.png /home/floory/.git-projects/inulude/node_modules/app-builder-lib/templates/icons/electron-linux/256x256.png=/usr/share/icons/hicolor/256x256/apps/perplexity-ai-app.png '/tmp/t-AmGBrQ/2-Perplexity AI.desktop=/usr/share/applications/perplexity-ai-app.desktop'
                    workingDir=
```

i don't use debian but this was the easiest solution i could find to making it build successfully :p (built on nixos without nix-shell so should build on any distro but i've not tested if the debian build works)

first PR, go easy on me :)