### PR TITLE
Add a second Perplexity tab to replace the AI Labs slot

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,8 +18,11 @@
   </div>
 </a>
 <div class="sidebar-separator" style="background-color: white; height: 1px; margin: 8px 0;"></div>
-      <a href="#" class="menu-item" onclick="window.electronAPI.switchAITool('https://perplexity.ai')">
+      <a href="#" class="menu-item" id="tab1-button" onclick="window.electronAPI.switchAITool('tab1')">
         <img src="./assets/icons/svg/perplexity-ai-icon.svg" alt="AI Search" title="AI Search"/>
+      </a>
+      <a href="#" class="menu-item" id="tab2-button" onclick="window.electronAPI.switchAITool('tab2')">
+        <img src="./assets/icons/svg/ai-icon.svg" alt="Second Tab" title="Second Tab (separate Perplexity workspace)"/>
       </a>
       <a href="#" class="menu-item" onclick="window.electronAPI.switchAITool('refresh')">
         <img src="./assets/icons/svg/refresh-icon.svg" alt="Refresh" title="Refresh"/>

--- a/main.js
+++ b/main.js
@@ -63,7 +63,24 @@ if (process.platform === 'win32') {
 
 let mainWindow;
 let currentView;
+
+// Two independent Perplexity workspaces. `views` is keyed by TAB ID, not by
+// URL: keying by URL meant two tabs pointing at the same site collapsed onto a
+// single cached BrowserView, so switching between them did nothing. Keying by
+// tab identity gives each tab its own BrowserView, and therefore its own
+// navigation history, scroll position and in-flight conversation.
+// Both tabs use the default Electron session, so cookies and localStorage --
+// and therefore the Perplexity login -- are shared between them.
+const TABS = [
+  { id: 'tab1', label: 'AI Search', home: 'https://perplexity.ai' },
+  { id: 'tab2', label: 'Second Tab', home: 'https://perplexity.ai' }
+];
+const DEFAULT_TAB_ID = TABS[0].id;
+const isTabId = (value) => TABS.some((tab) => tab.id === value);
+const tabHome = (tabId) => (TABS.find((tab) => tab.id === tabId) || TABS[0]).home;
+
 let views = {};
+let activeTabId = DEFAULT_TAB_ID;
 let findBarOpen = false;
 let tray = null;
 let settingsWindow = null;
@@ -170,6 +187,7 @@ function processCommandLineArgs(argv) {
 const defaultShortcuts = isMac
   ? {
       perplexityAI: { key: 'Command+1', enabled: false },
+      secondTab: { key: 'Command+2', enabled: false },
       sendToTray: { key: 'Command+W', enabled: false },
       restoreApp: { key: 'Command+Shift+Q', enabled: false },
       quickSearch: { key: 'Command+Shift+P', enabled: false },
@@ -177,6 +195,7 @@ const defaultShortcuts = isMac
     }
   : {
       perplexityAI: { key: 'Control+1', enabled: false },
+      secondTab: { key: 'Control+2', enabled: false },
       sendToTray: { key: 'Alt+Shift+W', enabled: false },
       restoreApp: { key: 'Alt+Shift+Q', enabled: false },
       quickSearch: { key: 'Alt+Shift+X', enabled: false },
@@ -201,6 +220,18 @@ function ensureShortcutsFormat() {
     settings.set('shortcuts', shortcuts);
   }
   
+  let hasAddedShortcuts = false;
+  for (const [key, value] of Object.entries(defaultShortcuts)) {
+    if (!shortcuts[key]) {
+      shortcuts[key] = { ...value };
+      hasAddedShortcuts = true;
+    }
+  }
+
+  if (hasAddedShortcuts) {
+    settings.set('shortcuts', shortcuts);
+  }
+
   const validShortcutKeys = Object.keys(defaultShortcuts);
   let hasRemovedShortcuts = false;
   
@@ -222,7 +253,8 @@ function registerShortcuts() {
   globalShortcut.unregisterAll();
 
   const shortcutActions = {
-    perplexityAI: () => switchView('https://perplexity.ai'),
+    perplexityAI: () => switchView('tab1'),
+    secondTab: () => switchView('tab2'),
     sendToTray: () => mainWindow.hide(),
     restoreApp: () => {
       if (mainWindow.isMinimized() || !mainWindow.isVisible()) {
@@ -624,20 +656,28 @@ app.on('before-quit', () => {
   }
 });
 
-// labs.perplexity.ai now 301s to playground.perplexity.ai and then to the
-// generic www.perplexity.ai homepage, so the AI Labs destination no longer
-// exists. Existing installs may still have it stored as their default site.
-function normalizeDefaultAI(url) {
-  if (typeof url === 'string' && url.includes('labs.perplexity.ai')) {
-    settings.set('defaultAI', 'https://perplexity.ai');
-    return 'https://perplexity.ai';
+// `defaultAI` now stores a tab id rather than a URL. Older installs may hold a
+// URL, including the dead labs.perplexity.ai destination (it 301s to
+// playground.perplexity.ai and then to the generic www.perplexity.ai homepage),
+// so map any legacy value onto a real tab and persist the migration.
+function normalizeDefaultAI(value) {
+  if (isTabId(value)) return value;
+
+  if (typeof value === 'string' && value.includes('labs.perplexity.ai')) {
+    settings.set('defaultAI', DEFAULT_TAB_ID);
+    return DEFAULT_TAB_ID;
   }
-  return url;
+
+  if (typeof value === 'string' && value.startsWith('http')) {
+    settings.set('defaultAI', DEFAULT_TAB_ID);
+    return DEFAULT_TAB_ID;
+  }
+
+  return DEFAULT_TAB_ID;
 }
 
 function loadDefaultAI() {
-  const defaultAI = normalizeDefaultAI(settings.get('defaultAI', 'https://perplexity.ai'));
-  switchView(defaultAI);
+  switchView(normalizeDefaultAI(settings.get('defaultAI', DEFAULT_TAB_ID)));
 }
 
 function adjustViewBounds() {
@@ -666,49 +706,53 @@ function isCtrlEnterToSendEnabled() {
   return settings.get('ctrlEnterToSend', false);
 }
 
-function switchView(url) {
-  if (url === 'refresh' && currentView) {
-    
-    const currentUrl = currentView.webContents.getURL();
-    let baseUrl;
-    
-    if (currentUrl.includes('perplexity.ai')) {
-      baseUrl = 'https://perplexity.ai';
-    } else {
-      baseUrl = normalizeDefaultAI(settings.get('defaultAI', 'https://perplexity.ai'));
+// Accepts a tab id ('tab1' / 'tab2'), 'refresh', 'search:<query>', or a plain
+// URL. Tab ids switch between the persistent tabs; anything that navigates
+// (quick search, the donate link) is loaded into whichever tab is active, the
+// same way a browser opens a link in the current tab.
+function switchView(target) {
+  if (target === 'refresh') {
+    const activeView = views[activeTabId] || currentView;
+    if (activeView) {
+      const home = tabHome(activeTabId);
+      console.log(`Refreshing ${activeTabId} to base URL: ${home}`);
+      activeView.webContents.loadURL(home);
     }
-    
-    console.log(`Refreshing to base URL: ${baseUrl}`);
-    currentView.webContents.loadURL(baseUrl);
     return;
   }
+
+  let tabId;
+  let navigateTo = null;
+
+  if (isTabId(target)) {
+    tabId = target;
+  } else if (typeof target === 'string' && target.startsWith('search:')) {
+    const searchQuery = target.substring(7).trim();
+    tabId = activeTabId;
+    navigateTo = searchQuery
+      ? `https://www.perplexity.ai/search?q=${encodeURIComponent(searchQuery)}`
+      : tabHome(tabId);
+  } else if (typeof target === 'string' && target.startsWith('http')) {
+    tabId = activeTabId;
+    navigateTo = target;
+  } else {
+    tabId = DEFAULT_TAB_ID;
+  }
+
+  const url = navigateTo || tabHome(tabId);
 
   if (currentView) {
     mainWindow.removeBrowserView(currentView);
   }
 
-  if (url.startsWith('search:')) {
-    const searchQuery = url.substring(7).trim();
-    if (searchQuery) {
-      url = `https://www.perplexity.ai/search?q=${encodeURIComponent(searchQuery)}`;
-    } else {
-      url = 'https://perplexity.ai';
+  // No eviction here any more. `views` holds exactly the fixed set of tabs, so
+  // the old maxCachedViews sweep could only ever destroy a live tab.
+  if (views[tabId]) {
+    currentView = views[tabId];
+    activeTabId = tabId;
+    if (navigateTo) {
+      currentView.webContents.loadURL(navigateTo);
     }
-  }
-
-  const maxCachedViews = 2; 
-  const viewUrls = Object.keys(views);
-  if (viewUrls.length > maxCachedViews && !views[url]) {
-    const oldestUrl = viewUrls[0];
-    const oldView = views[oldestUrl];
-    if (oldView) {
-      oldView.webContents.destroy();
-    }
-    delete views[oldestUrl];
-  }
-
-  if (views[url]) {
-    currentView = views[url];
   } else {
     currentView = new BrowserView({
       webPreferences: {
@@ -739,7 +783,8 @@ function switchView(url) {
     }
     
     currentView.webContents.loadURL(url);
-    views[url] = currentView;
+    views[tabId] = currentView;
+    activeTabId = tabId;
 
     currentView.webContents.setWindowOpenHandler(({ url }) => {
       shell.openExternal(url);
@@ -942,20 +987,13 @@ function cleanupUnusedResources() {
   if (global.gc) {
     global.gc();
   }
-  
-  const currentTime = Date.now();
-  const viewUrls = Object.keys(views);
-  
-  for (const url of viewUrls) {
-    if (views[url] === currentView) continue;
-    
-    if (!views[url].lastAccessTime || (currentTime - views[url].lastAccessTime > 300000)) {
-      if (views[url].webContents) {
-        views[url].webContents.destroy();
-      }
-      delete views[url];
-    }
-  }
+
+  // This used to destroy every view that was not the current one, gated on a
+  // `lastAccessTime` property that nothing ever assigned -- so the condition
+  // was always true and any backgrounded view was torn down on the next sweep.
+  // `views` now holds exactly the persistent tabs, whose whole purpose is to
+  // keep their state while backgrounded, so there is nothing here to reclaim.
+  // Idle cost is already bounded by backgroundThrottling on each view.
 }
 
 function createTray() {
@@ -1286,9 +1324,10 @@ ipcMain.on('close-settings', () => {
   }
 });
 
-ipcMain.on('switch-ai-tool', (event, url) => {
-  if (url.startsWith('http') || url === 'refresh' || url.startsWith('search:')) {
-    switchView(url);
+ipcMain.on('switch-ai-tool', (event, target) => {
+  if (typeof target !== 'string') return;
+  if (isTabId(target) || target.startsWith('http') || target === 'refresh' || target.startsWith('search:')) {
+    switchView(target);
   }
 });
 

--- a/notifications/notification-7.md
+++ b/notifications/notification-7.md
@@ -1,6 +1,6 @@
-# SimplexityAI v5.1.0 — Security fixes and Intel Mac support 🔒
+# SimplexityAI v5.1.0 — Security fixes, Intel Mac support, and a second tab 🔒
 
-Notification content is now sanitised before it renders, the macOS tray works again, and Intel Macs have a build for the first time since v5.0.0.
+Notification content is now sanitised before it renders, the macOS tray works again, Intel Macs have a build for the first time since v5.0.0, and the second sidebar tab is back as a proper second Perplexity workspace.
 
 ---
 
@@ -24,8 +24,13 @@ The macOS build was Apple Silicon only, so Intel Macs had nothing to download. m
 
 ## What's Changed
 
-### AI Labs has been removed
-Perplexity retired the Labs destination — `labs.perplexity.ai` no longer resolves — so the AI Labs button had been quietly loading the same site as AI Search. The button, its settings option and its shortcut are gone. If it was your default view, you'll be switched to AI Search rather than opening a dead page.
+### AI Labs is now a second tab
+Perplexity retired the Labs destination — `labs.perplexity.ai` no longer resolves — so the AI Labs button had been quietly loading the same site as AI Search.
+
+Since most people were using it as a second tab, that's what it now is. **Second Tab** opens an independent Perplexity workspace with its own conversation and history, switchable from the sidebar or with **Cmd/Ctrl+2**. Both tabs share your login. If AI Labs was your default view, you'll be switched to AI Search rather than opening a dead page.
+
+### Background tabs keep their state
+An inactive tab was being destroyed about five minutes after you switched away, so going back meant starting over. Both tabs now stay alive while the app is running.
 
 ### Smaller download list
 The macOS `.zip` has been removed; it only existed to serve an auto-updater this app doesn't use. The `.dmg` is unaffected.

--- a/notifications/notification-manifest.json
+++ b/notifications/notification-manifest.json
@@ -1,18 +1,18 @@
 {
-    "notifications": [
-      {
-        "id": "7",
-        "title": "SimplexityAI v5.1.0 — Security fixes and Intel Mac support",
-        "filename": "notification-7.md",
-        "date": "2026-08-16",
-        "priority": "high"
-      },
-      {
-        "id": "6",
-        "title": "Join Our Telegram Channel",
-        "filename": "notification-5.md",
-        "date": "2026-02-15",
-        "priority": "medium"
-      }
-    ]
-  }
+  "notifications": [
+    {
+      "id": "7",
+      "title": "SimplexityAI v5.1.0 \u2014 Security fixes, Intel Mac support, and a second tab",
+      "filename": "notification-7.md",
+      "date": "2026-08-16",
+      "priority": "high"
+    },
+    {
+      "id": "6",
+      "title": "Join Our Telegram Channel",
+      "filename": "notification-5.md",
+      "date": "2026-02-15",
+      "priority": "medium"
+    }
+  ]
+}

--- a/release_notes/v5.1.0.md
+++ b/release_notes/v5.1.0.md
@@ -1,6 +1,6 @@
 # SimplexityAI v5.1.0
 
-A security and packaging release. Notification content is now sanitised before rendering, Intel Macs get a build for the first time since v5.0.0, and the macOS tray icon works at all.
+A security and packaging release. Notification content is now sanitised before rendering, Intel Macs get a build for the first time since v5.0.0, the macOS tray icon works at all, and the second sidebar tab is back as a proper second Perplexity workspace.
 
 ---
 
@@ -36,10 +36,15 @@ The app's entitlements file was in the wrong directory and had never been applie
 
 ## Changed
 
-### AI Labs has been removed
+### AI Labs is now a second tab
 Perplexity retired the Labs destination. `labs.perplexity.ai` no longer resolves, and `perplexity.ai/labs` now lands on a product page rather than an app, so the AI Labs button had been quietly loading the same site as AI Search.
 
-The button, its settings option and its keyboard shortcut have been removed. If AI Labs was your default view, the app will switch you to AI Search on first launch rather than opening a dead page.
+Since that button was mostly being used as a *second tab*, that's what it now is. **Second Tab** opens an independent Perplexity workspace: its own conversation, history and scroll position, switchable from the sidebar or with **Cmd/Ctrl+2**. Both tabs share your login, so signing in once covers both.
+
+If AI Labs was your default view, the app switches you to AI Search rather than opening a dead page. You can set either tab as your startup view in Settings.
+
+### Background tabs no longer lose their state
+An inactive view was being destroyed roughly five minutes after you switched away from it, so returning to it meant starting over. This affected AI Labs too. Both tabs now stay alive for as long as the app is running.
 
 ### The Settings "Shortcuts" link works
 It previously opened the repository home page instead of the shortcuts documentation.

--- a/settings.html
+++ b/settings.html
@@ -21,7 +21,8 @@
             Default AI Site:
           </label>
           <select id="defaultAI">
-            <option value="https://perplexity.ai">AI Search</option>
+            <option value="tab1">AI Search</option>
+            <option value="tab2">Second Tab</option>
           </select>
         </div>
       </div>
@@ -71,6 +72,18 @@
           <input type="text" id="shortcut-perplexityAI" class="shortcut-input" readonly placeholder="Press keys..." required>
           <label class="toggle-switch">
             <input type="checkbox" id="toggle-perplexityAI" class="toggle-checkbox">
+            <span class="toggle-slider"></span>
+          </label>
+        </div>
+
+        <div class="shortcut-item">
+          <label>
+            <img src="./assets/icons/svg/ai-icon.svg" alt="Second Tab">
+            Second Tab:
+          </label>
+          <input type="text" id="shortcut-secondTab" class="shortcut-input" readonly placeholder="Press keys..." required>
+          <label class="toggle-switch">
+            <input type="checkbox" id="toggle-secondTab" class="toggle-checkbox">
             <span class="toggle-slider"></span>
           </label>
         </div>

--- a/src/js/renderer/renderer.js
+++ b/src/js/renderer/renderer.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (document.getElementById('settings-container')) {
     const shortcutFields = {
       perplexityAI: document.getElementById('shortcut-perplexityAI'),
+      secondTab: document.getElementById('shortcut-secondTab'),
       sendToTray: document.getElementById('shortcut-sendToTray'),
       restoreApp: document.getElementById('shortcut-restoreApp'),
       quickSearch: document.getElementById('shortcut-quickSearch'),
@@ -12,6 +13,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     const shortcutToggles = {
       perplexityAI: document.getElementById('toggle-perplexityAI'),
+      secondTab: document.getElementById('toggle-secondTab'),
       sendToTray: document.getElementById('toggle-sendToTray'),
       restoreApp: document.getElementById('toggle-restoreApp'),
       quickSearch: document.getElementById('toggle-quickSearch'),
@@ -139,7 +141,7 @@ document.addEventListener('DOMContentLoaded', () => {
       loadCurrentShortcuts();
       
       if (defaultAISelect) {
-        defaultAISelect.value = data.defaultAI || 'https://perplexity.ai';
+        defaultAISelect.value = data.defaultAI || 'tab1';
       }
       
       const autostartToggle = document.getElementById('toggle-autostart');
@@ -280,6 +282,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const defaultShortcuts = isMac
         ? {
             perplexityAI: { key: 'Command+1', enabled: false },
+            secondTab: { key: 'Command+2', enabled: false },
             sendToTray: { key: 'Command+T', enabled: false },
             restoreApp: { key: 'Command+Shift+T', enabled: false },
             quickSearch: { key: 'Command+Shift+X', enabled: false },
@@ -287,6 +290,7 @@ document.addEventListener('DOMContentLoaded', () => {
           }
         : {
             perplexityAI: { key: 'Control+1', enabled: false },
+            secondTab: { key: 'Control+2', enabled: false },
             sendToTray: { key: 'Alt+Shift+W', enabled: false },
             restoreApp: { key: 'Alt+Shift+Q', enabled: false },
             quickSearch: { key: 'Alt+Shift+X', enabled: false },
@@ -409,6 +413,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function getFriendlyName(key) {
       const nameMap = {
         perplexityAI: 'AI Search',
+        secondTab: 'Second Tab',
         sendToTray: 'Send to Tray',
         restoreApp: 'Restore App',
         quickSearch: 'Quick Search',
@@ -420,6 +425,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function getDefaultMacShortcut(key) {
       const defaults = {
         perplexityAI: 'Command+1',
+        secondTab: 'Command+2',
         sendToTray: 'Command+T',
         restoreApp: 'Command+Shift+T',
         quickSearch: 'Command+Shift+P',
@@ -431,6 +437,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function getDefaultWindowsShortcut(key) {
       const defaults = {
         perplexityAI: 'Control+1',
+        secondTab: 'Control+2',
         sendToTray: 'Alt+Shift+W',
         restoreApp: 'Alt+Shift+Q',
         quickSearch: 'Alt+Shift+X',
@@ -521,13 +528,21 @@ function closeSettings() {
 }
 
 function initNavigationButtons() {
-  const perplexityAIButton = document.querySelector('.menu-item[onclick*="perplexity.ai"]');
+  const perplexityAIButton = document.getElementById('tab1-button');
+  const secondTabButton = document.getElementById('tab2-button');
   const refreshButton = document.querySelector('.menu-item[onclick*="refresh"]');
   
   if (perplexityAIButton) {
     perplexityAIButton.addEventListener('click', (event) => {
       event.preventDefault();
-      window.electronAPI.switchAITool('https://perplexity.ai');
+      window.electronAPI.switchAITool('tab1');
+    });
+  }
+
+  if (secondTabButton) {
+    secondTabButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      window.electronAPI.switchAITool('tab2');
     });
   }
   


### PR DESCRIPTION
Removing AI Labs was correct — the destination is dead — but people were using that button as a *second tab*, not for Labs. This restores that capability as two independent Perplexity workspaces.

## Why it wasn't just re-adding a button

`views` in `main.js` was keyed by **URL**, and `switchView(url)` reused `views[url]`. AI Search and AI Labs only behaved as separate tabs because their URLs happened to differ. Two tabs both pointing at `perplexity.ai` would have collapsed onto one `BrowserView` and switching would have done nothing.

`views` is now keyed by tab id, so each tab keeps its own navigation history, scroll position and in-flight conversation. Both use the default session, so one sign-in covers both.

## Two latent bugs this surfaced

**Background views were destroyed after five minutes.** `cleanupUnusedResources` tore down any view that wasn't current when its `lastAccessTime` was older than 300s — but nothing ever assigned `lastAccessTime`, so the condition was always true and any backgrounded view was destroyed on the next sweep. AI Labs lost its state this way too. The sweep is removed; the fixed set of tabs is exactly what should stay alive, and idle cost is already bounded by `backgroundThrottling`.

**`maxCachedViews` eviction could only destroy a live tab** once the cache holds a fixed set, so it's gone as well.

## Verified in the running app

Driven through the real IPC the sidebar buttons use, 13 checks in total:

- tab1 navigated to `/library`, switch to tab2, switch back → **tab1 still on `/library`**
- tab2 gets its own view rather than reusing tab1's
- refresh acts on the **active** tab: tab2 sent to `/finance`, refreshed → tab2 home, tab1 still on `/library`
- both tabs use `session.defaultSession`, so login carries over
- enabling the Second Tab shortcut → `globalShortcut.isRegistered('Command+2') === true`
- `defaultAI: 'https://labs.perplexity.ai'` migrates to `tab1` on load
- `defaultAI: 'tab2'` boots on the second tab without being rewritten

## Notes

- `defaultAI` now stores a tab id; installs holding a URL, including the dead labs one, are migrated on load.
- Labelled "Second Tab" rather than reviving the AI Labs name, since it's a different thing.
- 5.1.0 release notes and the in-app notification are updated — they previously said Labs was removed with no replacement.

Not changed: anything in the release pipeline.