### PR TITLE
Reopen where you left off, and one source of truth for shortcut defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,16 +218,17 @@ npm run package-linux  # Creates .AppImage and .deb (Linux)
 
 ## ⌨️ Keyboard Shortcuts
 
-All shortcuts are **fully customizable** in Settings!
+All shortcuts are **fully customizable** in Settings, and are disabled by default — enable the ones you want.
 
 ### Default Shortcuts
 
 | Action | Windows/Linux | macOS | Description |
 |--------|---------------|-------|-------------|
-| **Quick Search** | `Alt+Shift+X` | `Cmd+Shift+X` | Search selected text from anywhere |
-| **Custom Prefix Search** | `Alt+Shift+D` | `Cmd+Shift+D` | Search with custom prefixes |
-| **Open P AI** | `Ctrl+1` | `Cmd+1` | Switch to P AI |
-| **Send to Tray** | `Alt+Shift+W` | `Cmd+T` | Minimize to system tray |
+| **Quick Search** | `Alt+Shift+X` | `Cmd+Shift+P` | Search selected text from anywhere |
+| **Custom Prefix Search** | `Alt+Shift+D` | `Cmd+Shift+C` | Search with custom prefixes |
+| **Open P AI** | `Ctrl+1` | `Cmd+1` | Switch to the first tab |
+| **Second Tab** | `Ctrl+2` | `Cmd+2` | Switch to the second tab |
+| **Send to Tray** | `Alt+Shift+W` | `Cmd+Shift+W` | Minimize to system tray |
 | **Restore from Tray** | `Alt+Shift+Q` | `Cmd+Shift+T` | Restore app window |
 | **Find in Page** | `Ctrl+F` | `Cmd+F` | Search text on current page |
 | **Zoom In** | `Ctrl+=` | `Cmd+=` | Increase text size |
@@ -245,7 +246,7 @@ Highlight any text on your desktop → Press your Quick Search hotkey → Instan
 
 **How it works:**
 1. Select text anywhere (browser, document, email, etc.)
-2. Press `Alt+Shift+X` (Windows/Linux) or `Cmd+Shift+X` (macOS)
+2. Press `Alt+Shift+X` (Windows/Linux) or `Cmd+Shift+P` (macOS)
 3. SimplexityAI opens with your search ready!
 
 ### 📋 **Prefix Search**

--- a/main.js
+++ b/main.js
@@ -188,8 +188,8 @@ const defaultShortcuts = isMac
   ? {
       perplexityAI: { key: 'Command+1', enabled: false },
       secondTab: { key: 'Command+2', enabled: false },
-      sendToTray: { key: 'Command+W', enabled: false },
-      restoreApp: { key: 'Command+Shift+Q', enabled: false },
+      sendToTray: { key: 'Command+Shift+W', enabled: false },
+      restoreApp: { key: 'Command+Shift+T', enabled: false },
       quickSearch: { key: 'Command+Shift+P', enabled: false },
       customPrefixSearch: { key: 'Command+Shift+C', enabled: false }
     }
@@ -702,6 +702,36 @@ function adjustViewBounds() {
   }
 }
 
+// Each tab remembers the page it was last on, so reopening the app puts you
+// back where you left off instead of dropping you on whatever perplexity.ai
+// happens to land on that week. Only perplexity.ai pages are restored, so a
+// stale or hostile stored value cannot send a tab somewhere unexpected.
+function isRestorableUrl(url) {
+  if (typeof url !== 'string') return false;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== 'https:') return false;
+    const host = parsed.hostname.toLowerCase();
+    return host === 'perplexity.ai' || host.endsWith('.perplexity.ai');
+  } catch {
+    return false;
+  }
+}
+
+function rememberTabUrl(tabId, url) {
+  if (!isTabId(tabId) || !isRestorableUrl(url)) return;
+  const stored = settings.get('tabUrls', {});
+  if (stored[tabId] === url) return;
+  stored[tabId] = url;
+  settings.set('tabUrls', stored);
+}
+
+function restoredTabUrl(tabId) {
+  if (settings.get('restoreLastSession', true) !== true) return tabHome(tabId);
+  const stored = settings.get('tabUrls', {});
+  return isRestorableUrl(stored[tabId]) ? stored[tabId] : tabHome(tabId);
+}
+
 function isCtrlEnterToSendEnabled() {
   return settings.get('ctrlEnterToSend', false);
 }
@@ -739,7 +769,7 @@ function switchView(target) {
     tabId = DEFAULT_TAB_ID;
   }
 
-  const url = navigateTo || tabHome(tabId);
+  const url = navigateTo || restoredTabUrl(tabId);
 
   if (currentView) {
     mainWindow.removeBrowserView(currentView);
@@ -785,6 +815,11 @@ function switchView(target) {
     currentView.webContents.loadURL(url);
     views[tabId] = currentView;
     activeTabId = tabId;
+
+    const trackedTabId = tabId;
+    const track = () => rememberTabUrl(trackedTabId, currentView.webContents.getURL());
+    currentView.webContents.on('did-navigate', track);
+    currentView.webContents.on('did-navigate-in-page', track);
 
     currentView.webContents.setWindowOpenHandler(({ url }) => {
       shell.openExternal(url);
@@ -1349,6 +1384,10 @@ ipcMain.on('set-settings', (event, data) => {
     configureAutoStart(data.autoStartEnabled);
   }
 
+  if (data.restoreLastSession !== undefined) {
+    settings.set('restoreLastSession', data.restoreLastSession);
+  }
+
   if (data.closeToTray !== undefined) {
     settings.set('closeToTray', data.closeToTray);
   }
@@ -1363,10 +1402,12 @@ ipcMain.on('set-settings', (event, data) => {
 ipcMain.on('get-settings', (event) => {
   const data = {
     shortcuts,
-    defaultAI: normalizeDefaultAI(settings.get('defaultAI', 'https://perplexity.ai')),
+    defaultAI: normalizeDefaultAI(settings.get('defaultAI', DEFAULT_TAB_ID)),
     disableHardwareAcceleration: settings.get('disableHardwareAcceleration', false),
     autoStartEnabled: autoStartEnabled,
     closeToTray: settings.get('closeToTray', true),
+    restoreLastSession: settings.get('restoreLastSession', true),
+    defaultShortcuts,
     ctrlEnterToSend: settings.get('ctrlEnterToSend', false)
   };
   event.sender.send('settings', data);

--- a/notifications/notification-7.md
+++ b/notifications/notification-7.md
@@ -32,6 +32,9 @@ Since most people were using it as a second tab, that's what it now is. **Second
 ### Background tabs keep their state
 An inactive tab was being destroyed about five minutes after you switched away, so going back meant starting over. Both tabs now stay alive while the app is running.
 
+### The app reopens where you left off
+Nothing remembered the page you were on, so every launch handed you back to perplexity.ai and the site decided where that landed — Computer, even if you were last on Search. Each tab now reopens where you left it, with a **Reopen where I left off** setting if you'd rather always start fresh.
+
 ### Smaller download list
 The macOS `.zip` has been removed; it only existed to serve an auto-updater this app doesn't use. The `.dmg` is unaffected.
 

--- a/release_notes/v5.1.0.md
+++ b/release_notes/v5.1.0.md
@@ -46,6 +46,12 @@ If AI Labs was your default view, the app switches you to AI Search rather than 
 ### Background tabs no longer lose their state
 An inactive view was being destroyed roughly five minutes after you switched away from it, so returning to it meant starting over. This affected AI Labs too. Both tabs now stay alive for as long as the app is running.
 
+### The app reopens where you left off
+Nothing was remembering the page you were on, so every launch loaded perplexity.ai and the site decided where that landed — which for a signed-in user is Computer, even if you were last on Search. Each tab now reopens on the page you left it on. There's a new **Reopen where I left off** setting if you'd rather always start on your default. Thanks to @Rustlyr for the report.
+
+### macOS keyboard shortcut defaults were inconsistent
+The defaults were defined in three places and had drifted apart, so **Restore Defaults** handed you bindings the app didn't actually register. There is now one definition. Two macOS defaults also changed, because global shortcuts shadow the binding in *every* application: **Send to Tray** moves from `Cmd+W` (Close Window) to `Cmd+Shift+W`, and **Restore from Tray** from `Cmd+Shift+Q` (macOS Log Out) to `Cmd+Shift+T`. Shortcuts you have already customised are untouched.
+
 ### The Settings "Shortcuts" link works
 It previously opened the repository home page instead of the shortcuts documentation.
 
@@ -71,4 +77,3 @@ The `.zip` existed only to support an auto-updater this app does not use. The `.
 ## Known limitations
 
 - macOS and Windows builds are **not code-signed**. Gatekeeper and SmartScreen will warn on first launch; on macOS, right-click the app and choose **Open** the first time. The signing path is wired and will activate once certificates are in place.
-- On macOS, the Settings "Restore Defaults" button writes different keyboard shortcuts than the app actually registers. Shortcuts are disabled by default, so this only affects you if you have enabled them. A fix is planned.

--- a/settings.html
+++ b/settings.html
@@ -39,6 +39,17 @@
       </div>
 
       <div class="setting-item">
+        <label for="restoreLastSession">
+          <img src="./assets/icons/svg/revert-icon.svg" alt="Restore Last Session">
+          Reopen where I left off:
+        </label>
+        <label class="toggle-switch">
+          <input type="checkbox" id="toggle-restoreLastSession" class="toggle-checkbox" checked>
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+
+      <div class="setting-item">
         <label for="closeToTray">
           <img src="./assets/icons/svg/tray-icon.svg" alt="Close to Tray">
           Close to Tray:

--- a/src/js/renderer/renderer.js
+++ b/src/js/renderer/renderer.js
@@ -64,9 +64,8 @@ document.addEventListener('DOMContentLoaded', () => {
           enabled: isEnabled
         };
       } else {
-        const defaultKey = isMac ? 
-          getDefaultMacShortcut(key) : 
-          getDefaultWindowsShortcut(key);
+        // Main already resolved the platform when it built the table.
+        const defaultKey = defaultShortcutKey(key);
         
         newShortcuts[key] = {
           key: defaultKey,
@@ -138,6 +137,10 @@ document.addEventListener('DOMContentLoaded', () => {
       newShortcuts = { ...processedShortcuts };
       savedShortcuts = { ...processedShortcuts };
     
+      if (data.defaultShortcuts) {
+        window.__defaultShortcuts = data.defaultShortcuts;
+      }
+
       loadCurrentShortcuts();
       
       if (defaultAISelect) {
@@ -151,6 +154,11 @@ document.addEventListener('DOMContentLoaded', () => {
         autostartToggle.addEventListener('change', (event) => {
           window.electronAPI.toggleAutostart(event.target.checked);
         });
+      }
+
+      const restoreLastSessionToggle = document.getElementById('toggle-restoreLastSession');
+      if (restoreLastSessionToggle) {
+        restoreLastSessionToggle.checked = data.restoreLastSession !== false;
       }
 
       const closeToTrayToggle = document.getElementById('toggle-closeToTray');
@@ -279,23 +287,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('restore-button').addEventListener('click', () => {
-      const defaultShortcuts = isMac
-        ? {
-            perplexityAI: { key: 'Command+1', enabled: false },
-            secondTab: { key: 'Command+2', enabled: false },
-            sendToTray: { key: 'Command+T', enabled: false },
-            restoreApp: { key: 'Command+Shift+T', enabled: false },
-            quickSearch: { key: 'Command+Shift+X', enabled: false },
-            customPrefixSearch: { key: 'Command+Shift+D', enabled: false }
-          }
-        : {
-            perplexityAI: { key: 'Control+1', enabled: false },
-            secondTab: { key: 'Control+2', enabled: false },
-            sendToTray: { key: 'Alt+Shift+W', enabled: false },
-            restoreApp: { key: 'Alt+Shift+Q', enabled: false },
-            quickSearch: { key: 'Alt+Shift+X', enabled: false },
-            customPrefixSearch: { key: 'Alt+Shift+D', enabled: false }
-          };
+      // Defaults come from the main process, which is the only place they are
+      // defined. Keeping a second copy here is how the two drifted apart.
+      const defaultShortcuts = window.__defaultShortcuts || {};
 
       newShortcuts = { ...defaultShortcuts };
       savedShortcuts = { ...defaultShortcuts };
@@ -307,6 +301,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (checkForDuplicates(true)) {
         const autostartToggle = document.getElementById('toggle-autostart');
         
+        const restoreLastSessionToggle = document.getElementById('toggle-restoreLastSession');
         const closeToTrayToggle = document.getElementById('toggle-closeToTray');
         const ctrlEnterToSendToggle = document.getElementById('toggle-ctrlEnterToSend');
 
@@ -317,6 +312,7 @@ document.addEventListener('DOMContentLoaded', () => {
             ? document.getElementById('toggle-hardware-acceleration').checked
             : false,
           autoStartEnabled: autostartToggle ? autostartToggle.checked : false,
+          restoreLastSession: restoreLastSessionToggle ? restoreLastSessionToggle.checked : true,
           closeToTray: closeToTrayToggle ? closeToTrayToggle.checked : true,
           ctrlEnterToSend: ctrlEnterToSendToggle ? ctrlEnterToSendToggle.checked : false
         };
@@ -410,6 +406,11 @@ document.addEventListener('DOMContentLoaded', () => {
       return [...modifiers, key].join('+').toLowerCase();
     }
 
+    function defaultShortcutKey(key) {
+      const defaults = window.__defaultShortcuts || {};
+      return (defaults[key] && defaults[key].key) || '';
+    }
+
     function getFriendlyName(key) {
       const nameMap = {
         perplexityAI: 'AI Search',
@@ -422,29 +423,7 @@ document.addEventListener('DOMContentLoaded', () => {
       return nameMap[key] || key;
     }
     
-    function getDefaultMacShortcut(key) {
-      const defaults = {
-        perplexityAI: 'Command+1',
-        secondTab: 'Command+2',
-        sendToTray: 'Command+T',
-        restoreApp: 'Command+Shift+T',
-        quickSearch: 'Command+Shift+P',
-        customPrefixSearch: 'Command+Shift+C'
-      };
-      return defaults[key] || '';
-    }
     
-    function getDefaultWindowsShortcut(key) {
-      const defaults = {
-        perplexityAI: 'Control+1',
-        secondTab: 'Control+2',
-        sendToTray: 'Alt+Shift+W',
-        restoreApp: 'Alt+Shift+Q',
-        quickSearch: 'Alt+Shift+X',
-        customPrefixSearch: 'Alt+Shift+D'
-      };
-      return defaults[key] || '';
-    }
   } else if (document.getElementById('prefix-search-container')) {
     const prefixButtons = document.querySelectorAll('.prefix-button');
     const selectedTextElement = document.getElementById('selected-text');


### PR DESCRIPTION
Two fixes, plus the docs that were wrong about both.

## Reopens where you left off — reported on #51

@Rustlyr reported the app reopening on Computer even after leaving it on Search. Verified: **nothing was persisting the current page.** Every launch loaded `perplexity.ai` and the site decided where that landed — for a signed-in user, Computer.

Each tab now records its page on `did-navigate` / `did-navigate-in-page` and reopens there, behind a **Reopen where I left off** setting (default on) so anyone who prefers a fixed start page keeps one. Only `perplexity.ai` hosts are restored, so a stale or tampered stored value can't redirect a tab somewhere unexpected.

## macOS shortcut defaults disagreed in three places

| Action | `main.js` *(registers)* | "Restore Defaults" | `getDefaultMacShortcut` |
|---|---|---|---|
| sendToTray | `Cmd+W` | `Cmd+T` | `Cmd+T` |
| restoreApp | `Cmd+Shift+Q` | `Cmd+Shift+T` | `Cmd+Shift+T` |
| quickSearch | `Cmd+Shift+P` | `Cmd+Shift+X` | `Cmd+Shift+P` |
| customPrefixSearch | `Cmd+Shift+C` | `Cmd+Shift+D` | `Cmd+Shift+C` |

So **Restore Defaults handed you bindings the app doesn't register.** `main.js` is now the only definition and ships it to the settings window over the existing `get-settings` payload; the renderer's table *and* both `getDefault*Shortcut` helpers are deleted.

Two macOS defaults also changed, because these are `globalShortcut` registrations that shadow the binding in **every** application:

- `sendToTray`: `Cmd+W` → `Cmd+Shift+W` — `Cmd+W` is Close Window
- `restoreApp`: `Cmd+Shift+Q` → `Cmd+Shift+T` — `Cmd+Shift+Q` is macOS **Log Out**

Already-customised shortcuts are untouched; `ensureShortcutsFormat` only adds missing keys. This changes fresh installs and what Restore Defaults produces.

## Also

- `get-settings` passed a URL as the `defaultAI` fallback, so `normalizeDefaultAI` rewrote and **persisted** a setting every time the settings window opened.
- The README shortcut table matched none of the three definitions.

## Verified in the running app — 8/8

- navigating records the tab url → `{"tab1":"https://www.perplexity.ai/library"}`
- reopening returns to `/library`
- toggle off falls back to the tab home
- a stored `https://evil.example.com/x` is ignored, tab opens on perplexity.ai
- main sends `defaultShortcuts` to the settings window
- `sendToTray` no longer `Cmd+W`; `restoreApp` no longer `Cmd+Shift+Q`
- a fresh install stores exactly the advertised defaults