### PR TITLE
Optional Perplexity sidebar shortcuts, and repair nag-screen removal

### DIFF
--- a/main.js
+++ b/main.js
@@ -1432,6 +1432,11 @@ ipcMain.on('set-settings', (event, data) => {
     settings.set('restoreLastSession', data.restoreLastSession);
   }
 
+  if (Array.isArray(data.sidebarShortcuts)) {
+    settings.set('sidebarShortcuts', data.sidebarShortcuts);
+    broadcastSidebarShortcuts();
+  }
+
   if (data.closeToTray !== undefined) {
     settings.set('closeToTray', data.closeToTray);
   }
@@ -1443,6 +1448,18 @@ ipcMain.on('set-settings', (event, data) => {
   reattachShortcuts();
 });
 
+// The sidebar injector in preload_inject.js asks for this on every page load.
+ipcMain.handle('get-sidebar-shortcuts', () => settings.get('sidebarShortcuts', []));
+
+function broadcastSidebarShortcuts() {
+  const ids = settings.get('sidebarShortcuts', []);
+  Object.values(views).forEach((view) => {
+    if (view && view.webContents && !view.webContents.isDestroyed()) {
+      view.webContents.send('sidebar-shortcuts-changed', ids);
+    }
+  });
+}
+
 ipcMain.on('get-settings', (event) => {
   const data = {
     shortcuts,
@@ -1451,6 +1468,7 @@ ipcMain.on('get-settings', (event) => {
     autoStartEnabled: autoStartEnabled,
     closeToTray: settings.get('closeToTray', true),
     restoreLastSession: settings.get('restoreLastSession', true),
+    sidebarShortcuts: settings.get('sidebarShortcuts', []),
     defaultShortcuts,
     ctrlEnterToSend: settings.get('ctrlEnterToSend', false)
   };

--- a/preload_inject.js
+++ b/preload_inject.js
@@ -1,0 +1,129 @@
+window.addEventListener('DOMContentLoaded', () => {
+    const isLabs = window.location.hostname.includes('labs.perplexity.ai');
+    const isMain = window.location.hostname.includes('perplexity.ai') && !isLabs;
+
+    const mainSelectors = [
+        'div.items-stretch.md\\:items-center.fill-mode-both.fixed.bottom-0.left-0.right-0.top-0.bg-backdrop\\/70.backdrop-blur-sm.animate-in.fade-in.ease-outExpo.duration-200',
+        'div.max-w-\\[400px\\].overflow-hidden.rounded-xl.md\\:flex.md\\:max-w-\\[960px\\].border-borderMain\\/50',
+        'relative.flex.flex-col.p-lg.md\\:w-\\[45\\%\\].md\\:p-xl',
+        'md\\:h-\\[55\\%\\].md\\:w-\\[55\\%\\]',
+        'rounded-lg.p-md.duration-300.ease-out.animate-in.fade-in.\\!p-lg.border-borderMain\\/50.ring-borderMain\\/50.divide-borderMain\\/50.dark\\:divide-borderMainDark\\/50.dark\\:ring-borderMainDark\\/50.dark\\:border-borderMainDark\\/50.bg-offset.dark\\:bg-offsetDark',
+        
+    ];
+
+    const labsSelectors = [
+        'div.flex.items-center.gap-sm'
+    ];
+
+
+    // Perplexity keeps Discover, Finance, Personal CFO, Health, Academic and
+    // Patents behind the top-right menu, which is two clicks away. These add
+    // them to its own left sidebar instead.
+    //
+    // The menu entries do not exist in the DOM until the menu is opened, so
+    // they cannot be moved -- we build our own. Each item is cloned from a real
+    // sidebar entry so it inherits Perplexity's markup, spacing and theming,
+    // and the icons reference their own sprite (651 symbols, all six verified
+    // present). That survives styling changes far better than hand-written CSS.
+    const SIDEBAR_LINKS = [
+        { label: 'Discover',     path: '/discover', icon: 'pplx-icon-compass' },
+        { label: 'Finance',      path: '/finance',  icon: 'pplx-icon-chart-area-line' },
+        { label: 'Personal CFO', path: '/cfo',      icon: 'pplx-icon-wallet' },
+        { label: 'Health',       path: '/health',   icon: 'pplx-icon-heart' },
+        { label: 'Academic',     path: '/academic', icon: 'pplx-icon-school' },
+        { label: 'Patents',      path: '/patents',  icon: 'pplx-icon-gavel' },
+    ];
+
+    const INJECTED_ATTR = 'data-simplexity-shortcut';
+    let injecting = false;
+
+    function injectSidebarLinks() {
+        // Our own insertions retrigger the observer; without this the callback
+        // recurses while the DOM is still being written.
+        if (injecting) return;
+
+        const nav = document.querySelector('nav[class*="group/sidebar"]');
+        if (!nav) return;
+
+        // Never clone one of our own items, or edits compound.
+        const templateAnchor = [...nav.querySelectorAll('a[href^="/"][class*="absolute"]')]
+            .find((a) => !a.closest('[' + INJECTED_ATTR + ']'));
+        if (!templateAnchor) return;
+
+        const template = templateAnchor.closest('[class*="collapsible-sidebar-section"]');
+        if (!template || !template.parentElement) return;
+
+        injecting = true;
+        try {
+            let after = template;
+            // Keep our block together and in order, after whatever is already there.
+            const existing = nav.querySelectorAll('[' + INJECTED_ATTR + ']');
+            if (existing.length) after = existing[existing.length - 1];
+
+            for (const link of SIDEBAR_LINKS) {
+                if (nav.querySelector('[' + INJECTED_ATTR + '="' + link.path + '"]')) continue;
+
+                const clone = template.cloneNode(true);
+                clone.setAttribute(INJECTED_ATTR, link.path);
+
+                const anchor = clone.querySelector('a[href]');
+                if (!anchor) continue;
+                anchor.setAttribute('href', link.path);
+                anchor.setAttribute('aria-label', link.label);
+
+                const use = clone.querySelector('svg use');
+                if (use) {
+                    use.setAttribute('xlink:href', '#' + link.icon);
+                    use.setAttribute('href', '#' + link.icon);
+                }
+
+                // The label is the deepest text-bearing node in the cloned row.
+                const labelEl = [...clone.querySelectorAll('div')]
+                    .reverse()
+                    .find((d) => d.children.length === 0 && d.textContent.trim().length > 0);
+                if (labelEl) labelEl.textContent = link.label;
+
+                after.parentElement.insertBefore(clone, after.nextSibling);
+                after = clone;
+            }
+        } finally {
+            injecting = false;
+        }
+    }
+
+    // querySelectorAll throws a SyntaxError on a malformed selector, and this
+    // runs inside a DOMContentLoaded listener, so one bad entry took the whole
+    // script down with it -- including the MutationObserver registration below.
+    // That is why nag screens were never actually being removed. Isolate each
+    // selector so a future typo degrades instead of disabling everything.
+    function removeNagScreens(selectors) {
+        selectors.forEach((selector) => {
+            try {
+                document.querySelectorAll(selector).forEach((el) => {
+                    el.remove();
+                });
+            } catch (err) {
+                console.warn('[simplexity] skipping invalid nag-screen selector:', selector, err.message);
+            }
+        });
+    }
+
+    if (isLabs) {
+        removeNagScreens(labsSelectors);
+    } else if (isMain) {
+        removeNagScreens(mainSelectors);
+        injectSidebarLinks();
+    }
+
+
+    const observer = new MutationObserver(() => {
+        if (isLabs) {
+            removeNagScreens(labsSelectors);
+        } else if (isMain) {
+            removeNagScreens(mainSelectors);
+            injectSidebarLinks();
+        }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+});

--- a/settings.html
+++ b/settings.html
@@ -38,6 +38,21 @@
         </label>
       </div>
 
+      <div class="setting-item" style="flex-direction: column; align-items: flex-start; gap: 8px;">
+        <label>
+          <img src="./assets/icons/svg/ai-icon.svg" alt="Perplexity sidebar">
+          Show in Perplexity's sidebar:
+        </label>
+        <div id="sidebarShortcuts" style="display: flex; flex-direction: column; gap: 6px; width: 100%; padding-left: 4px;">
+          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="discover"> Discover</label>
+          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="finance"> Finance</label>
+          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="cfo"> Personal CFO</label>
+          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="health"> Health</label>
+          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="academic"> Academic</label>
+          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="patents"> Patents</label>
+        </div>
+      </div>
+
       <div class="setting-item">
         <label for="restoreLastSession">
           <img src="./assets/icons/svg/revert-icon.svg" alt="Restore Last Session">

--- a/settings.html
+++ b/settings.html
@@ -38,18 +38,19 @@
         </label>
       </div>
 
-      <div class="setting-item" style="flex-direction: column; align-items: flex-start; gap: 8px;">
+      <div class="sidebar-shortcuts-item">
         <label>
-          <img src="./assets/icons/svg/ai-icon.svg" alt="Perplexity sidebar">
+          <img src="./assets/icons/svg/perplexity-ai-icon.svg" alt="">
           Show in Perplexity's sidebar:
         </label>
-        <div id="sidebarShortcuts" style="display: flex; flex-direction: column; gap: 6px; width: 100%; padding-left: 4px;">
-          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="discover"> Discover</label>
-          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="finance"> Finance</label>
-          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="cfo"> Personal CFO</label>
-          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="health"> Health</label>
-          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="academic"> Academic</label>
-          <label class="shortcut-toggle-row"><input type="checkbox" class="sidebar-shortcut" value="patents"> Patents</label>
+        <p class="sidebar-shortcuts-hint">Adds shortcuts to Perplexity's own left sidebar. Choose any; leave all unticked to keep it unchanged.</p>
+        <div class="sidebar-shortcuts-grid" id="sidebarShortcuts">
+          <label class="sidebar-shortcut-chip"><input type="checkbox" class="sidebar-shortcut" value="discover">Discover</label>
+          <label class="sidebar-shortcut-chip"><input type="checkbox" class="sidebar-shortcut" value="finance">Finance</label>
+          <label class="sidebar-shortcut-chip"><input type="checkbox" class="sidebar-shortcut" value="cfo">Personal CFO</label>
+          <label class="sidebar-shortcut-chip"><input type="checkbox" class="sidebar-shortcut" value="health">Health</label>
+          <label class="sidebar-shortcut-chip"><input type="checkbox" class="sidebar-shortcut" value="academic">Academic</label>
+          <label class="sidebar-shortcut-chip"><input type="checkbox" class="sidebar-shortcut" value="patents">Patents</label>
         </div>
       </div>
 

--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -86,7 +86,7 @@ body {
   min-width: 140px;
 }
 
-.setting-item label img, .shortcut-item label img {
+.setting-item label img, .shortcut-item label img, .sidebar-shortcuts-item label img {
   width: 20px;
   height: 20px;
   margin-right: 8px;
@@ -344,6 +344,13 @@ input[type="checkbox"]:not(:checked) + .toggle-slider {
 /* Perplexity sidebar shortcuts — a multi-select, so chips rather than a
    column of six switches: it stays compact and reads as "pick any". Colours
    reuse the toggle palette so it sits with the rest of the panel. */
+.sidebar-shortcuts-item label {
+  display: flex;
+  align-items: center;
+  font-size: 0.9em;
+  color: #E8E8E6;
+}
+
 .sidebar-shortcuts-item {
   display: flex;
   flex-direction: column;

--- a/src/css/settings.css
+++ b/src/css/settings.css
@@ -341,3 +341,86 @@ input[type="checkbox"]:not(:checked) + .toggle-slider {
 ::-webkit-scrollbar {
   width: 8px;
 }
+/* Perplexity sidebar shortcuts — a multi-select, so chips rather than a
+   column of six switches: it stays compact and reads as "pick any". Colours
+   reuse the toggle palette so it sits with the rest of the panel. */
+.sidebar-shortcuts-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  margin-bottom: 15px;
+  width: 100%;
+}
+
+.sidebar-shortcuts-hint {
+  font-size: 0.78em;
+  color: #8a8d92;
+  margin: 2px 0 10px 26px;
+  line-height: 1.4;
+}
+
+.sidebar-shortcuts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  width: 100%;
+}
+
+.sidebar-shortcut-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px;
+  border: 1px solid #383a3f;
+  border-radius: 6px;
+  background-color: transparent;
+  color: #9a9da2;
+  font-size: 0.85em;
+  cursor: pointer;
+  transition: background-color .2s, border-color .2s, color .2s;
+  user-select: none;
+}
+
+.sidebar-shortcut-chip:hover {
+  border-color: #1E4D53;
+  color: #E8E8E6;
+}
+
+/* The tick is the state indicator; the fill alone is too subtle on dark. */
+.sidebar-shortcut-chip::before {
+  content: "";
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border: 1px solid #55585e;
+  border-radius: 4px;
+  transition: background-color .2s, border-color .2s;
+}
+
+.sidebar-shortcut-chip:has(input:checked) {
+  background-color: #1E4D53;
+  border-color: #2f7d87;
+  color: #E8E8E6;
+}
+
+.sidebar-shortcut-chip:has(input:checked)::before {
+  background-color: #E8E8E6;
+  border-color: #E8E8E6;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%231E4D53' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M3 8.5l3.2 3.2L13 5'/%3E%3C/svg%3E");
+  background-size: 12px 12px;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.sidebar-shortcut-chip input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* Keyboard users need to see focus, since the real input is hidden. */
+.sidebar-shortcut-chip:focus-within {
+  outline: 2px solid #2f7d87;
+  outline-offset: 2px;
+}

--- a/src/js/preload/preload_inject.js
+++ b/src/js/preload/preload_inject.js
@@ -1,3 +1,5 @@
+const { ipcRenderer } = require('electron');
+
 window.addEventListener('DOMContentLoaded', () => {
     const isLabs = window.location.hostname.includes('labs.perplexity.ai');
     const isMain = window.location.hostname.includes('perplexity.ai') && !isLabs;
@@ -17,54 +19,72 @@ window.addEventListener('DOMContentLoaded', () => {
 
 
     // Perplexity keeps Discover, Finance, Personal CFO, Health, Academic and
-    // Patents behind the top-right menu, which is two clicks away. These add
-    // them to its own left sidebar instead.
+    // Patents behind the top-right menu, two clicks away. A user can promote
+    // any of them into its left sidebar from Settings; nothing is added unless
+    // they ask for it, so the default install leaves Perplexity's UI alone.
     //
-    // The menu entries do not exist in the DOM until the menu is opened, so
-    // they cannot be moved -- we build our own. Each item is cloned from a real
-    // sidebar entry so it inherits Perplexity's markup, spacing and theming,
-    // and the icons reference their own sprite (651 symbols, all six verified
-    // present). That survives styling changes far better than hand-written CSS.
-    const SIDEBAR_LINKS = [
-        { label: 'Discover',     path: '/discover', icon: 'pplx-icon-compass' },
-        { label: 'Finance',      path: '/finance',  icon: 'pplx-icon-chart-area-line' },
-        { label: 'Personal CFO', path: '/cfo',      icon: 'pplx-icon-wallet' },
-        { label: 'Health',       path: '/health',   icon: 'pplx-icon-heart' },
-        { label: 'Academic',     path: '/academic', icon: 'pplx-icon-school' },
-        { label: 'Patents',      path: '/patents',  icon: 'pplx-icon-gavel' },
+    // The menu entries do not exist in the DOM until that menu is opened, so
+    // they cannot be moved -- each one is rebuilt by cloning a real sidebar
+    // row, which inherits Perplexity's markup, spacing and theming. Icons come
+    // from their own sprite.
+    const AVAILABLE_SHORTCUTS = [
+        { id: 'discover', label: 'Discover',     path: '/discover', icon: 'pplx-icon-compass' },
+        { id: 'finance',  label: 'Finance',      path: '/finance',  icon: 'pplx-icon-chart-area-line' },
+        { id: 'cfo',      label: 'Personal CFO', path: '/cfo',      icon: 'pplx-icon-wallet' },
+        { id: 'health',   label: 'Health',       path: '/health',   icon: 'pplx-icon-heart' },
+        { id: 'academic', label: 'Academic',     path: '/academic', icon: 'pplx-icon-school' },
+        { id: 'patents',  label: 'Patents',      path: '/patents',  icon: 'pplx-icon-gavel' },
     ];
 
     const INJECTED_ATTR = 'data-simplexity-shortcut';
+    let enabledIds = [];
     let injecting = false;
 
-    function injectSidebarLinks() {
-        // Our own insertions retrigger the observer; without this the callback
-        // recurses while the DOM is still being written.
+    function setLabel(clone, text) {
+        // The label is the truncating text node in the cloned row. Matching on
+        // the class is far more reliable than walking for "the last leaf with
+        // text", which picked the wrong node and left every row reading "New".
+        const el = clone.querySelector('[class*="truncate"]')
+            || [...clone.querySelectorAll('div, span')]
+                .reverse()
+                .find((d) => d.children.length === 0 && d.textContent.trim().length > 0);
+        if (el) el.textContent = text;
+        return !!el;
+    }
+
+    function syncSidebarLinks() {
         if (injecting) return;
 
         const nav = document.querySelector('nav[class*="group/sidebar"]');
         if (!nav) return;
 
-        // Never clone one of our own items, or edits compound.
-        const templateAnchor = [...nav.querySelectorAll('a[href^="/"][class*="absolute"]')]
-            .find((a) => !a.closest('[' + INJECTED_ATTR + ']'));
-        if (!templateAnchor) return;
-
-        const template = templateAnchor.closest('[class*="collapsible-sidebar-section"]');
-        if (!template || !template.parentElement) return;
-
         injecting = true;
         try {
+            // Drop anything the user has since unticked.
+            nav.querySelectorAll('[' + INJECTED_ATTR + ']').forEach((el) => {
+                if (!enabledIds.includes(el.getAttribute(INJECTED_ATTR))) el.remove();
+            });
+
+            const wanted = AVAILABLE_SHORTCUTS.filter((s) => enabledIds.includes(s.id));
+            if (!wanted.length) return;
+
+            // Never clone one of our own rows, or the edits compound.
+            const templateAnchor = [...nav.querySelectorAll('a[href^="/"][class*="absolute"]')]
+                .find((a) => !a.closest('[' + INJECTED_ATTR + ']'));
+            if (!templateAnchor) return;
+
+            const template = templateAnchor.closest('[class*="collapsible-sidebar-section"]');
+            if (!template || !template.parentElement) return;
+
             let after = template;
-            // Keep our block together and in order, after whatever is already there.
             const existing = nav.querySelectorAll('[' + INJECTED_ATTR + ']');
             if (existing.length) after = existing[existing.length - 1];
 
-            for (const link of SIDEBAR_LINKS) {
-                if (nav.querySelector('[' + INJECTED_ATTR + '="' + link.path + '"]')) continue;
+            for (const link of wanted) {
+                if (nav.querySelector('[' + INJECTED_ATTR + '="' + link.id + '"]')) continue;
 
                 const clone = template.cloneNode(true);
-                clone.setAttribute(INJECTED_ATTR, link.path);
+                clone.setAttribute(INJECTED_ATTR, link.id);
 
                 const anchor = clone.querySelector('a[href]');
                 if (!anchor) continue;
@@ -77,11 +97,9 @@ window.addEventListener('DOMContentLoaded', () => {
                     use.setAttribute('href', '#' + link.icon);
                 }
 
-                // The label is the deepest text-bearing node in the cloned row.
-                const labelEl = [...clone.querySelectorAll('div')]
-                    .reverse()
-                    .find((d) => d.children.length === 0 && d.textContent.trim().length > 0);
-                if (labelEl) labelEl.textContent = link.label;
+                // If the label cannot be set the row would read as a copy of
+                // whatever was cloned, which is worse than not adding it.
+                if (!setLabel(clone, link.label)) continue;
 
                 after.parentElement.insertBefore(clone, after.nextSibling);
                 after = clone;
@@ -112,7 +130,7 @@ window.addEventListener('DOMContentLoaded', () => {
         removeNagScreens(labsSelectors);
     } else if (isMain) {
         removeNagScreens(mainSelectors);
-        injectSidebarLinks();
+        syncSidebarLinks();
     }
 
 
@@ -121,9 +139,20 @@ window.addEventListener('DOMContentLoaded', () => {
             removeNagScreens(labsSelectors);
         } else if (isMain) {
             removeNagScreens(mainSelectors);
-            injectSidebarLinks();
+            syncSidebarLinks();
         }
     });
 
     observer.observe(document.body, { childList: true, subtree: true });
+
+    ipcRenderer.invoke('get-sidebar-shortcuts').then((ids) => {
+        enabledIds = Array.isArray(ids) ? ids : [];
+        syncSidebarLinks();
+    }).catch(() => {});
+
+    // Applying changes without a reload keeps Settings feeling immediate.
+    ipcRenderer.on('sidebar-shortcuts-changed', (_event, ids) => {
+        enabledIds = Array.isArray(ids) ? ids : [];
+        syncSidebarLinks();
+    });
 });

--- a/src/js/preload/preload_inject.js
+++ b/src/js/preload/preload_inject.js
@@ -7,7 +7,7 @@ window.addEventListener('DOMContentLoaded', () => {
         'div.max-w-\\[400px\\].overflow-hidden.rounded-xl.md\\:flex.md\\:max-w-\\[960px\\].border-borderMain\\/50',
         'relative.flex.flex-col.p-lg.md\\:w-\\[45\\%\\].md\\:p-xl',
         'md\\:h-\\[55\\%\\].md\\:w-\\[55\\%\\]',
-        'rounded-lg.p-md.duration-300.ease-out.animate-in.fade-in.!p-lg.border-borderMain\\/50.ring-borderMain\\/50.divide-borderMain\\/50.dark\\:divide-borderMainDark\\/50.dark\\:ring-borderMainDark\\/50.dark\\:border-borderMainDark\\/50.bg-offset.dark\\:bg-offsetDark',
+        'rounded-lg.p-md.duration-300.ease-out.animate-in.fade-in.\\!p-lg.border-borderMain\\/50.ring-borderMain\\/50.divide-borderMain\\/50.dark\\:divide-borderMainDark\\/50.dark\\:ring-borderMainDark\\/50.dark\\:border-borderMainDark\\/50.bg-offset.dark\\:bg-offsetDark',
         
     ];
 
@@ -15,11 +15,96 @@ window.addEventListener('DOMContentLoaded', () => {
         'div.flex.items-center.gap-sm'
     ];
 
+
+    // Perplexity keeps Discover, Finance, Personal CFO, Health, Academic and
+    // Patents behind the top-right menu, which is two clicks away. These add
+    // them to its own left sidebar instead.
+    //
+    // The menu entries do not exist in the DOM until the menu is opened, so
+    // they cannot be moved -- we build our own. Each item is cloned from a real
+    // sidebar entry so it inherits Perplexity's markup, spacing and theming,
+    // and the icons reference their own sprite (651 symbols, all six verified
+    // present). That survives styling changes far better than hand-written CSS.
+    const SIDEBAR_LINKS = [
+        { label: 'Discover',     path: '/discover', icon: 'pplx-icon-compass' },
+        { label: 'Finance',      path: '/finance',  icon: 'pplx-icon-chart-area-line' },
+        { label: 'Personal CFO', path: '/cfo',      icon: 'pplx-icon-wallet' },
+        { label: 'Health',       path: '/health',   icon: 'pplx-icon-heart' },
+        { label: 'Academic',     path: '/academic', icon: 'pplx-icon-school' },
+        { label: 'Patents',      path: '/patents',  icon: 'pplx-icon-gavel' },
+    ];
+
+    const INJECTED_ATTR = 'data-simplexity-shortcut';
+    let injecting = false;
+
+    function injectSidebarLinks() {
+        // Our own insertions retrigger the observer; without this the callback
+        // recurses while the DOM is still being written.
+        if (injecting) return;
+
+        const nav = document.querySelector('nav[class*="group/sidebar"]');
+        if (!nav) return;
+
+        // Never clone one of our own items, or edits compound.
+        const templateAnchor = [...nav.querySelectorAll('a[href^="/"][class*="absolute"]')]
+            .find((a) => !a.closest('[' + INJECTED_ATTR + ']'));
+        if (!templateAnchor) return;
+
+        const template = templateAnchor.closest('[class*="collapsible-sidebar-section"]');
+        if (!template || !template.parentElement) return;
+
+        injecting = true;
+        try {
+            let after = template;
+            // Keep our block together and in order, after whatever is already there.
+            const existing = nav.querySelectorAll('[' + INJECTED_ATTR + ']');
+            if (existing.length) after = existing[existing.length - 1];
+
+            for (const link of SIDEBAR_LINKS) {
+                if (nav.querySelector('[' + INJECTED_ATTR + '="' + link.path + '"]')) continue;
+
+                const clone = template.cloneNode(true);
+                clone.setAttribute(INJECTED_ATTR, link.path);
+
+                const anchor = clone.querySelector('a[href]');
+                if (!anchor) continue;
+                anchor.setAttribute('href', link.path);
+                anchor.setAttribute('aria-label', link.label);
+
+                const use = clone.querySelector('svg use');
+                if (use) {
+                    use.setAttribute('xlink:href', '#' + link.icon);
+                    use.setAttribute('href', '#' + link.icon);
+                }
+
+                // The label is the deepest text-bearing node in the cloned row.
+                const labelEl = [...clone.querySelectorAll('div')]
+                    .reverse()
+                    .find((d) => d.children.length === 0 && d.textContent.trim().length > 0);
+                if (labelEl) labelEl.textContent = link.label;
+
+                after.parentElement.insertBefore(clone, after.nextSibling);
+                after = clone;
+            }
+        } finally {
+            injecting = false;
+        }
+    }
+
+    // querySelectorAll throws a SyntaxError on a malformed selector, and this
+    // runs inside a DOMContentLoaded listener, so one bad entry took the whole
+    // script down with it -- including the MutationObserver registration below.
+    // That is why nag screens were never actually being removed. Isolate each
+    // selector so a future typo degrades instead of disabling everything.
     function removeNagScreens(selectors) {
         selectors.forEach((selector) => {
-            document.querySelectorAll(selector).forEach((el) => {
-                el.remove();
-            });
+            try {
+                document.querySelectorAll(selector).forEach((el) => {
+                    el.remove();
+                });
+            } catch (err) {
+                console.warn('[simplexity] skipping invalid nag-screen selector:', selector, err.message);
+            }
         });
     }
 
@@ -27,13 +112,16 @@ window.addEventListener('DOMContentLoaded', () => {
         removeNagScreens(labsSelectors);
     } else if (isMain) {
         removeNagScreens(mainSelectors);
+        injectSidebarLinks();
     }
+
 
     const observer = new MutationObserver(() => {
         if (isLabs) {
             removeNagScreens(labsSelectors);
         } else if (isMain) {
             removeNagScreens(mainSelectors);
+            injectSidebarLinks();
         }
     });
 

--- a/src/js/renderer/renderer.js
+++ b/src/js/renderer/renderer.js
@@ -161,6 +161,11 @@ document.addEventListener('DOMContentLoaded', () => {
         restoreLastSessionToggle.checked = data.restoreLastSession !== false;
       }
 
+      const chosenShortcuts = Array.isArray(data.sidebarShortcuts) ? data.sidebarShortcuts : [];
+      document.querySelectorAll('.sidebar-shortcut').forEach((box) => {
+        box.checked = chosenShortcuts.includes(box.value);
+      });
+
       const closeToTrayToggle = document.getElementById('toggle-closeToTray');
       if (closeToTrayToggle) {
         closeToTrayToggle.checked = data.closeToTray !== false;
@@ -313,6 +318,9 @@ document.addEventListener('DOMContentLoaded', () => {
             : false,
           autoStartEnabled: autostartToggle ? autostartToggle.checked : false,
           restoreLastSession: restoreLastSessionToggle ? restoreLastSessionToggle.checked : true,
+          sidebarShortcuts: [...document.querySelectorAll('.sidebar-shortcut')]
+            .filter((box) => box.checked)
+            .map((box) => box.value),
           closeToTray: closeToTrayToggle ? closeToTrayToggle.checked : true,
           ctrlEnterToSend: ctrlEnterToSendToggle ? ctrlEnterToSendToggle.checked : false
         };


### PR DESCRIPTION
Requested by a user: the Discover / Finance / Personal CFO / Health / Academic / Patents destinations sit behind Perplexity's top-right ☰ menu, two clicks away.

## The bug this uncovered

Nag-screen removal has never worked on perplexity.ai. One `mainSelectors` entry has an unescaped `!` in `.!p-lg`, which is not valid CSS, so `querySelectorAll` threw a `SyntaxError`. `removeNagScreens` had no error handling and runs inside the `DOMContentLoaded` listener, so the throw **aborted the entire script — including the `MutationObserver` registration below it.** Everything after the first bad selector was dead code.

Escaped it, and isolated each selector so a future typo costs one selector rather than the whole injector. All six verified parseable by Chromium against a blank local page.

## The feature

Settings → **Show in Perplexity's sidebar** lists the six destinations as checkboxes. Only ticked ones are injected, so a default install leaves Perplexity's UI untouched. Unticking removes the row, and changes are pushed to open views over IPC so they apply without a reload.

The menu entries do not exist in the DOM until the menu is opened, so they cannot be moved — each row is rebuilt by cloning a real sidebar entry, inheriting Perplexity's markup, spacing and theming, with icons from their own sprite.

Paths confirmed by loading each: `/discover`, `/finance`, `/cfo`, `/health`, `/academic`, `/patents`. Note `/cfo` is the real Personal CFO page; `/personal-cfo` is a generic catch-all.

## Two UI bugs fixed along the way

- **Every row read "New".** The label swap looked for "the last leaf element with text" in the cloned row and matched the wrong node — icons were correct, labels were not. It now targets the truncating label by class, and skips a row entirely if the label cannot be set, since a row mislabelled as a copy of its template is worse than an absent one.
- **The settings panel layout broke.** The new container did not match `.setting-item label img, .shortcut-item label img`, so the section SVG rendered at natural size and pushed the panel apart. Verified fixed by rendering `settings.html` offscreen and measuring: 20×20, same as every other section.

## Verification

Confirmed working in an installed build on macOS by the maintainer. My own automated checks were limited — Perplexity's Cloudflare protection started challenging repeated Electron page loads, so the in-page behaviour was verified manually rather than by harness.